### PR TITLE
fix: subscription, new heads

### DIFF
--- a/core/api/src/jsonrpc/web3_types.rs
+++ b/core/api/src/jsonrpc/web3_types.rs
@@ -787,7 +787,9 @@ pub struct Web3Header {
     pub gas_used:          U64,
     pub logs_bloom:        Option<Bloom>,
     pub miner:             H160,
-    pub nonce:             U256,
+    pub nonce:             H64,
+    pub mix_hash:          H256,
+    pub hash:              H256,
     pub number:            U256,
     pub parent_hash:       H256,
     pub receipts_root:     H256,
@@ -814,7 +816,9 @@ impl From<Header> for Web3Header {
             gas_limit:         h.gas_limit,
             gas_used:          h.gas_used,
             timestamp:         h.timestamp.into(),
-            nonce:             U256::default(),
+            nonce:             H64::default(),
+            mix_hash:          H256::default(),
+            hash:              h.hash(),
         }
     }
 }

--- a/core/api/src/jsonrpc/ws_subscription.rs
+++ b/core/api/src/jsonrpc/ws_subscription.rs
@@ -134,7 +134,7 @@ where
                 let msg = SubscriptionMessage::from_json(&web3_header).unwrap();
 
                 for hub in self.header_hubs.iter_mut() {
-                    let _ignore = hub.sink.send(msg.clone());
+                    let _ignore = hub.sink.send(msg.clone()).await;
                 }
             }
 
@@ -142,7 +142,7 @@ where
             let msg = SubscriptionMessage::from_json(&latest_web3_header).unwrap();
 
             for hub in self.header_hubs.iter_mut() {
-                let _ignore = hub.sink.send(msg.clone());
+                let _ignore = hub.sink.send(msg.clone()).await;
             }
         }
 
@@ -153,7 +153,7 @@ where
 
             for hub in self.sync_hubs.iter_mut() {
                 // unbound sender can ignore it's return
-                let _ignore = hub.sink.send(msg.clone());
+                let _ignore = hub.sink.send(msg.clone()).await;
             }
         }
 
@@ -198,7 +198,7 @@ where
                         for log in logs.drain(..) {
                             let msg = SubscriptionMessage::from_json(&log).unwrap();
                             // unbound sender can ignore it's return
-                            let _ignore = hub.sink.send(msg);
+                            let _ignore = hub.sink.send(msg).await;
                         }
                     }
                     index += log_len;


### PR DESCRIPTION
Fix subscription. Without `await` nothing will ever be actually sent to subscribers!

And make the `Web3Header` type compatible with alloy.