### PR TITLE
fix(api): reject future to_block in get logs

### DIFF
--- a/core/api/src/jsonrpc/error.rs
+++ b/core/api/src/jsonrpc/error.rs
@@ -35,6 +35,8 @@ pub enum RpcError {
     InvalidBlockHash,
     #[display(fmt = "Invalid from block number {}", _0)]
     InvalidFromBlockNumber(u64),
+    #[display(fmt = "Invalid to block number {}", _0)]
+    InvalidToBlockNumber(u64),
     #[display(fmt = "Invalid block range from {} to {} limit to {}", _0, _1, _2)]
     InvalidBlockRange(u64, u64, u64),
     #[display(fmt = "Invalid newest block {:?}", _0)]
@@ -84,6 +86,7 @@ impl RpcError {
             RpcError::CannotGetLatestBlock => -40013,
             RpcError::InvalidBlockHash => -40014,
             RpcError::InvalidFromBlockNumber(_) => -40015,
+            RpcError::InvalidToBlockNumber(_) => -40026,
             RpcError::InvalidBlockRange(_, _, _) => -40016,
             RpcError::InvalidNewestBlock(_) => -40017,
             RpcError::InvalidPosition(_) => -40018,
@@ -123,6 +126,7 @@ impl From<RpcError> for ErrorObjectOwned {
             RpcError::CannotGetLatestBlock => ErrorObject::owned(err_code, err, none_data),
             RpcError::InvalidBlockHash => ErrorObject::owned(err_code, err, none_data),
             RpcError::InvalidFromBlockNumber(_) => ErrorObject::owned(err_code, err, none_data),
+            RpcError::InvalidToBlockNumber(_) => ErrorObject::owned(err_code, err, none_data),
             RpcError::InvalidBlockRange(_, _, _) => ErrorObject::owned(err_code, err, none_data),
             RpcError::InvalidNewestBlock(_) => ErrorObject::owned(err_code, err, none_data),
             RpcError::InvalidPosition(_) => ErrorObject::owned(err_code, err, none_data),

--- a/core/api/src/jsonrpc/impl/web3.rs
+++ b/core/api/src/jsonrpc/impl/web3.rs
@@ -689,15 +689,16 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
 
                     (
                         filter.from_block.map(convert).unwrap_or(latest_number),
-                        std::cmp::min(
-                            filter.to_block.map(convert).unwrap_or(latest_number),
-                            latest_number,
-                        ),
+                        filter.to_block.map(convert).unwrap_or(latest_number),
                     )
                 };
 
                 if start > latest_number {
                     return Err(RpcError::InvalidFromBlockNumber(start).into());
+                }
+
+                if end > latest_number {
+                    return Err(RpcError::InvalidToBlockNumber(end).into());
                 }
 
                 if end.saturating_sub(start) > self.log_filter_max_block_range {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR ...

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OpenZeppelin tests
- [ ] v3 Core Tests

### **CI Description**

| CI Name                | Description                                                                                             |
| ---------------------- | ------------------------------------------------------------------------------------------------------- |
| *Web3 Compatible Test* | Test the Web3 compatibility of Axon                                                                     |
| *v3 Core Test*         | Run the compatibility tests provided by Uniswap V3                                                      |
| *OpenZeppelin tests*   | Run the compatibility tests provided by OpenZeppelin, including OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19 |
</details>
